### PR TITLE
feat: build words from shuffled character tiles

### DIFF
--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -1,0 +1,24 @@
+export function shuffleNonTrivial(chars) {
+  const original = chars.slice();
+  if (original.length <= 1) return original;
+  const isTrivial = (arr) =>
+    arr.every((c, i) => c === original[i]) ||
+    (arr[0] === original[0] && arr[1] === original[1]);
+  let shuffled = [];
+  let attempts = 0;
+  do {
+    shuffled = original.slice();
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    attempts++;
+    if (!isTrivial(shuffled)) return shuffled;
+  } while (attempts < 5);
+  // Forzar swap si sigue siendo trivial
+  const i = Math.floor(Math.random() * shuffled.length);
+  let j = Math.floor(Math.random() * shuffled.length);
+  while (j === i) j = Math.floor(Math.random() * shuffled.length);
+  [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  return shuffled;
+}


### PR DESCRIPTION
## Summary
- split target words into individual character tiles and track player attempts
- add non-trivial Fisher–Yates shuffling helper with reseeding to avoid linear order
- scale exercise card by 5% and add undo support

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json)*
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1b2a1e06c83259cacffa83b68a84c