### PR TITLE
Fix page initialization error causing blank screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -274,7 +274,6 @@ chineseData.levels = [
 ];
 // Extender a 20 niveles
 chineseData.levels = extendLevels(chineseData.levels);
-chineseData.levels = normalizeLevels(chineseData.levels);
 
 
 // --- App (idéntico flujo del canvas) ---
@@ -350,6 +349,8 @@ export default function App() {
     ...lvl,
     exercises: (lvl.exercises || []).map(ensureCharWords),
   }));
+
+  chineseData.levels = normalizeLevels(chineseData.levels);
 
   // Pool global ES para distractores desde niveles 7..20
   const spanishPoolFromLevels = (levels, minId = 7) => {


### PR DESCRIPTION
## Summary
- Move level normalization call until after helper functions initialize
- Prevent `ReferenceError` so app loads instead of showing a blank page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2202ef458832595cf912591bc98f2