### PR TITLE
Add floating summary panel and safe JSON parsing

### DIFF
--- a/src/components/FloatingPanel.jsx
+++ b/src/components/FloatingPanel.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function FloatingPanel({ open, title, children, onClose, actions = [] }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="relative z-10 w-[min(520px,92vw)] bg-white rounded-2xl shadow-xl p-6">
+        {title ? <h3 className="text-xl font-semibold mb-3">{title}</h3> : null}
+        <div className="mb-5">{children}</div>
+        <div className="flex flex-wrap gap-3 justify-end">
+          {actions.map((a, i) => (
+            <button
+              key={i}
+              onClick={a.onClick}
+              className={a.className || 'px-4 py-2 rounded-xl border'}
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/utils/safeJson.js
+++ b/src/utils/safeJson.js
@@ -1,0 +1,11 @@
+export const stripTrailingCommas = (s = '') => s.replace(/,\s*([}\]])/g, '$1');
+
+export const safeParseJson = (s, fallback = null) => {
+  try {
+    return JSON.parse(stripTrailingCommas(s));
+  } catch (e) {
+    console.warn('[safeParseJson]', e);
+    return fallback;
+  }
+};
+


### PR DESCRIPTION
## Summary
- Replace full-screen exam summary with reusable `FloatingPanel` overlay and navigation handlers.
- Implement safe exam reset and next-level logic without `startGame` references.
- Add `safeParseJson` utility to guard against malformed JSON.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b223b97be083258f5f1c3ff9faaddd