### PR TITLE
Integrate lives rescue minigame into game over screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -285,9 +285,8 @@ export default function App() {
   const [currentExercise, setCurrentExercise] = useState(0);
   const [lives, setLives] = useState(5);
 
-  const [rescueSummary, setRescueSummary] = React.useState(null);
-
-  const [showRescue, setShowRescue] = React.useState(false);
+  const [showRescue, setShowRescue] = useState(false);
+  const [rescueSummary, setRescueSummary] = useState(null);
   const [showDictionary, setShowDictionary] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [tiles, setTiles] = useState([]);
@@ -661,7 +660,50 @@ export default function App() {
                   <button onClick={()=>{ setGameOverType(null); setCurrentLevel(1); setCurrentExercise(0); }} className="px-4 py-2 rounded-xl border">Pantalla principal</button>
                 </div>
               </div>
-    
+              {showRescue && (
+                <RescueLivesGame
+                  levels={chineseData.levels}
+                  currentLevel={currentLevel}
+                  onClose={({ pagesCompleted, totalPages, hearts }) => {
+                    setShowRescue(false);
+                    // Otorgar vidas y salir del Game Over si ganó al menos 1
+                    if (hearts === 'full') {
+                      setLives(5);
+                      setGameOverType(null);
+                      setRescueSummary({ hearts: 'full', pagesCompleted, totalPages });
+                    } else if (hearts >= 2) {
+                      setLives(prev => Math.min(5, (prev || 0) + 2));
+                      setGameOverType(null);
+                      setRescueSummary({ hearts: 2, pagesCompleted, totalPages });
+                    } else if (hearts === 1) {
+                      setLives(prev => Math.min(5, (prev || 0) + 1));
+                      setGameOverType(null);
+                      setRescueSummary({ hearts: 1, pagesCompleted, totalPages });
+                    } else {
+                      // 0 páginas → sin premio, sigue en game over
+                      setRescueSummary({ hearts: 0, pagesCompleted, totalPages });
+                    }
+                  }}
+                />
+              )}
+              <FloatingPanel
+                open={!!rescueSummary && rescueSummary.hearts !== 0}
+                title="¡Vidas recuperadas!"
+                onClose={() => setRescueSummary(null)}
+                actions={[{
+                  label: 'Volver al juego',
+                  className: 'px-4 py-2 rounded-xl bg-emerald-600 text-white',
+                  onClick: () => { setRescueSummary(null); setGameOverType(null); }
+                }]}
+              >
+                <div className="text-gray-700">
+                  {rescueSummary?.hearts === 'full' ? (
+                    <p>¡Completaste todas las páginas ({rescueSummary?.totalPages}) y recuperaste <b>todas</b> las vidas!</p>
+                  ) : (
+                    <p>Completaste {rescueSummary?.pagesCompleted} / {rescueSummary?.totalPages} páginas y recuperaste <b>{rescueSummary?.hearts}</b> {rescueSummary?.hearts===1?'vida':'vidas'}.</p>
+                  )}
+                </div>
+              </FloatingPanel>
             </>
           ) : (
             <>
@@ -901,88 +943,6 @@ export default function App() {
                 </div>
               </div>
             
-{showRescue && (
-  <RescueLivesGame
-    levels={chineseData.levels}
-    currentLevel={currentLevel}
-    maxLives={5}
-    onClose={({ pagesCompleted, totalPages, hearts }) => {
-      setShowRescue(false);
-      // Calcular corazones a otorgar
-      if (hearts === 'full') {
-        setLives(5);
-        setGameOverType(null);
-        setRescueSummary({ hearts: 'full', pagesCompleted, totalPages });
-      } else if (hearts >= 2) {
-        setLives(prev => Math.min(5, (prev || 0) + 2));
-        setGameOverType(null);
-        setRescueSummary({ hearts: 2, pagesCompleted, totalPages });
-      } else if (hearts === 1) {
-        setLives(prev => Math.min(5, (prev || 0) + 1));
-        setGameOverType(null);
-        setRescueSummary({ hearts: 1, pagesCompleted, totalPages });
-      } else {
-        // Sin premio: permanecemos en game over
-        setRescueSummary({ hearts: 0, pagesCompleted, totalPages });
-      }
-    }}
-  />
-)}
-<FloatingPanel
-  open={!!rescueSummary && rescueSummary.hearts !== 0}
-  title="¡Vidas recuperadas!"
-  onClose={()=>setRescueSummary(null)}
-  actions={[{ label:'Continuar', className:'px-4 py-2 rounded-xl bg-emerald-600 text-white', onClick:()=>{ setRescueSummary(null); } }]}
->
-  <div className="text-gray-700">
-    {rescueSummary?.hearts === 'full' ? (
-      <p>¡Completaste todas las páginas ({rescueSummary?.totalPages}) y recuperaste <b>todas</b> las vidas!</p>
-    ) : (
-      <p>Completaste {rescueSummary?.pagesCompleted} / {rescueSummary?.totalPages} páginas y recuperaste <b>{rescueSummary?.hearts}</b> {rescueSummary?.hearts===1?'vida':'vidas'}.</p>
-    )}
-  </div>
-</FloatingPanel>
-
-{showRescue && (
-  <RescueLivesGame
-    levels={chineseData.levels}
-    currentLevel={currentLevel}
-    onClose={({ pagesCompleted, totalPages, hearts }) => {
-      setShowRescue(false);
-      // Sumar vidas según desempeño
-      if (hearts === 'full') {
-        setLives(5);
-        setGameOverType(null);
-        setRescueSummary({ hearts: 'full', pagesCompleted, totalPages });
-      } else if (hearts >= 2) {
-        setLives(prev => Math.min(5, (prev || 0) + 2));
-        setGameOverType(null);
-        setRescueSummary({ hearts: 2, pagesCompleted, totalPages });
-      } else if (hearts === 1) {
-        setLives(prev => Math.min(5, (prev || 0) + 1));
-        setGameOverType(null);
-        setRescueSummary({ hearts: 1, pagesCompleted, totalPages });
-      } else {
-        // Sin premio: quedarse en la pantalla de game over
-        setRescueSummary({ hearts: 0, pagesCompleted, totalPages });
-      }
-    }}
-  />
-)}
-<FloatingPanel
-  open={!!rescueSummary && rescueSummary.hearts !== 0}
-  title="¡Vidas recuperadas!"
-  onClose={()=>setRescueSummary(null)}
-  actions={[{ label:'Volver al juego', className:'px-4 py-2 rounded-xl bg-emerald-600 text-white', onClick:()=>{ setRescueSummary(null); setGameOverType(null); } }]}
->
-  <div className="text-gray-700">
-    {rescueSummary?.hearts === 'full' ? (
-      <p>¡Completaste todas las páginas ({rescueSummary?.totalPages}) y recuperaste <b>todas</b> las vidas!</p>
-    ) : (
-      <p>Completaste {rescueSummary?.pagesCompleted} / {rescueSummary?.totalPages} páginas y recuperaste <b>{rescueSummary?.hearts}</b> {rescueSummary?.hearts===1?'vida':'vidas'}.</p>
-    )}
-  </div>
-</FloatingPanel>
 </div>
           );
         })()}

--- a/src/components/RescueLivesGame.jsx
+++ b/src/components/RescueLivesGame.jsx
@@ -151,7 +151,7 @@ export default function RescueLivesGame({ levels, currentLevel, maxLives = 5, on
   if (totalPages <= 0) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center"
+    <div className="fixed inset-0 z-[60] flex items-center justify-center"
          onMouseMove={onMove} onMouseUp={onUp}
          onTouchMove={onMove} onTouchEnd={onUp}>
       <div className="absolute inset-0 bg-black/40" />


### PR DESCRIPTION
## Summary
- Track rescue minigame state and summary with new `showRescue` and `rescueSummary` hooks
- Embed RescueLivesGame and reward panel in the `noLives` game-over branch
- Elevate RescueLivesGame overlay with higher z-index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b241b71dac8325937a595ce9f38bb5