### PR TITLE
feat: add streak bonus for rescue game

### DIFF
--- a/src/components/RescueLivesGame.jsx
+++ b/src/components/RescueLivesGame.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import FloatingPanel from './FloatingPanel.jsx';
 
 // =================== utils ===================
 function uniqueBy(arr, keyFn) {
@@ -58,10 +59,92 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
   // intro antes de empezar
   const [showIntro, setShowIntro] = React.useState(true);
 
+  // Racha de aciertos consecutivos (para disparar el bonus)
+  const [streak, setStreak] = React.useState(0);
+
+  // Bonus (comodín)
+  const [bonusOpen, setBonusOpen] = React.useState(false);        // muestra el panel del bonus
+  const [bonusAwarded, setBonusAwarded] = React.useState(false);  // ya ganado en esta sesión
+  const [bonusLives, setBonusLives] = React.useState(0);          // 0 o 1
+
+  // Fuente para el bonus: palabras resueltas en la sesión (multi-caracter)
+  const sessionSolvedWordsRef = React.useRef(new Set());
+
+  // Utilidades para bonus
+  const toCharTokens = (hanzi, pinyin) => {
+    const chars = Array.from((hanzi || '').replace(/\s+/g, ''));
+    const pys = (pinyin || '').trim().split(/\s+/);
+    return chars.map((c, i) => ({ char: c, pinyin: pys[i] || pys[pys.length-1] || '' }));
+  };
+
+  // Construir los 10 tokens del bonus (random) desde lo ya jugado
+  const buildBonusTokens = React.useCallback(() => {
+    // Preferimos palabras MULTICARÁCTER resueltas
+    const solved = Array.from(sessionSolvedWordsRef.current);
+    // fallback: agregar del pool de la página actual
+    const extras = pairs.map(p => p.left.hanzi);
+
+    const sourceWords = Array.from(new Set([...solved, ...extras])).filter(w => w && w.length >= 1);
+    let tokens = [];
+    for (const w of sourceWords) {
+      const py = pairs.find(p => p.left.hanzi === w)?.left?.pinyin || '';
+      tokens.push(...toCharTokens(w, py));
+    }
+    // barajar y limitar a 10
+    for (let i=tokens.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [tokens[i],tokens[j]]=[tokens[j],tokens[i]]; }
+    return tokens.slice(0, 10);
+  }, [pairs]);
+
+  // Objetivos válidos (3) que el alumno puede formar
+  const buildBonusTargets = React.useCallback(() => {
+    // Candidatos: palabras multi-caracter ya resueltas (o de la página actual)
+    const solved = Array.from(sessionSolvedWordsRef.current).filter(w => w.length >= 2);
+    let candidates = [...solved];
+    if (candidates.length < 3) {
+      candidates.push(...pairs.map(p => p.left.hanzi).filter(w => (w || '').replace(/\s+/g,'').length >= 2));
+    }
+    candidates = Array.from(new Set(candidates)).slice(0, 3);
+    // Si aún hay menos de 3, rellena con las que haya (aunque sean 1 char)
+    while (candidates.length < 3 && pairs[candidates.length]) {
+      candidates.push(pairs[candidates.length].left.hanzi);
+    }
+    return candidates.slice(0, 3);
+  }, [pairs]);
+
+  // Estado del UI del bonus
+  const [bonusTokens, setBonusTokens] = React.useState([]);
+  const [bonusTargets, setBonusTargets] = React.useState([]); // array de hanzi válidos
+  const [bonusBuild, setBonusBuild] = React.useState([]);     // indices elegidos del array bonusTokens
+
+  React.useEffect(() => {
+    if (bonusOpen) {
+      setBonusTokens(buildBonusTokens());
+      setBonusTargets(buildBonusTargets());
+      setBonusBuild([]);
+    }
+  }, [bonusOpen, buildBonusTokens, buildBonusTargets]);
+
+  const addBonusToken = (idx) => {
+    setBonusBuild(prev => (prev.includes(idx) ? prev : [...prev, idx]));
+  };
+  const removeBonusToken = (idx) => {
+    setBonusBuild(prev => prev.filter(i => i !== idx));
+  };
+  const currentBonusString = () => bonusTokens.filter((_,i)=>bonusBuild.includes(i)).map(t=>t.char).join('');
+  const tryBonus = () => {
+    const str = currentBonusString();
+    const ok = bonusTargets.some(t => t.replace(/\s+/g,'') === str);
+    if (ok) {
+      setBonusLives(1);
+      setBonusAwarded(true);
+    }
+    setBonusOpen(false); // cerrar bonus tras intentar (ganado o no)
+  };
+
   // construir página
   React.useEffect(() => {
     if (totalPages <= 0) {
-      onClose?.({ pagesCompleted: 0, totalPages: 0, hearts: 0 });
+      onClose?.({ pagesCompleted: 0, totalPages: 0, hearts: 0, bonusLives: 0 });
       return;
     }
     const startIndex = page * 5;
@@ -88,14 +171,25 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
     }
 
     if (leftKey === rightKey) {
-      // acierto
+      // ✅ acierto
       setSolvedKeys(prev => new Set([...prev, leftKey]));
-    } else {
-      // error: se comporta como las vidas globales → -1 corazón local
-      setMiniLives(v => {
-        const next = Math.max(0, (v || 0) - 1);
-        return next;
+      setStreak(prev => {
+        const s = prev + 1;
+
+        // Guarda la palabra/hanzi resuelta en la sesión (para alimentar el bonus)
+        const solvedHanzi = pairs[leftSel]?.left?.hanzi || '';
+        if (solvedHanzi) sessionSolvedWordsRef.current.add(solvedHanzi);
+
+        // Disparo de bonus: exactamente al llegar a 5 seguidos y aún no otorgado
+        if (s === 5 && !bonusAwarded) {
+          setBonusOpen(true);
+        }
+        return s;
       });
+    } else {
+      // ❌ error → pierde 1 vida local y resetea racha
+      setMiniLives(v => Math.max(0, (v || 0) - 1));
+      setStreak(0);
     }
     // limpiar selección
     const t = setTimeout(() => { setLeftSel(-1); setRightSel(-1); }, 150);
@@ -105,7 +199,7 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
   // si se quedan sin corazones locales → cerrar sin premio
   React.useEffect(() => {
     if (miniLives === 0) {
-      onClose?.({ pagesCompleted, totalPages, hearts: 0 });
+      onClose?.({ pagesCompleted, totalPages, hearts: 0, bonusLives });
     }
   }, [miniLives]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -120,7 +214,7 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
         // premio final (esto afecta a las vidas GLOBALES afuera del minijuego)
         const hearts = (finished === totalPages) ? 'full'
           : (finished >= 3 ? 2 : (finished === 1 ? 1 : 0));
-        onClose?.({ pagesCompleted: finished, totalPages, hearts });
+        onClose?.({ pagesCompleted: finished, totalPages, hearts, bonusLives });
       }
     }
   }, [solvedKeys]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -154,7 +248,7 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
       <div className="relative z-10 bg-white w-[min(960px,96vw)] max-h-[90vh] overflow-auto rounded-3xl shadow-2xl p-6">
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-semibold">Rescatar vidas — Página {page+1} / {totalPages}</h3>
-          <button className="px-3 py-1 rounded-lg border" onClick={()=>onClose?.({ pagesCompleted, totalPages, hearts: 0 })}>Salir</button>
+          <button className="px-3 py-1 rounded-lg border" onClick={()=>onClose?.({ pagesCompleted, totalPages, hearts: 0, bonusLives })}>Salir</button>
         </div>
 
         {/* corazones locales (6) arriba del panel */}
@@ -211,6 +305,50 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
               })}
             </div>
           </div>
+        )}
+
+        {/* BONUS: ordenar hanzi para formar una palabra/frase válida */}
+        {bonusOpen && (
+          <FloatingPanel
+            open={true}
+            title="Comodín por racha — Ordena los caracteres"
+            onClose={() => setBonusOpen(false)}
+            actions={[
+              { label:'Probar', className:'px-4 py-2 rounded-xl bg-emerald-600 text-white', onClick: tryBonus }
+            ]}
+          >
+            <div className="text-sm text-gray-700 mb-3">
+              Elige caracteres en orden para formar <b>una</b> de estas palabras/frases (no hay pistas).
+            </div>
+
+            {/* Zona de construcción */}
+            <div className="min-h-12 p-3 mb-3 rounded-xl bg-gray-50 border">
+              <div className="flex flex-wrap gap-2">
+                {bonusBuild.map((i) => (
+                  <button key={'sel-'+i} onClick={() => removeBonusToken(i)}
+                    className="px-3 py-1 rounded-lg bg-emerald-100">
+                    {bonusTokens[i]?.char} <span className="text-[10px] text-gray-500">{bonusTokens[i]?.pinyin}</span>
+                  </button>
+                ))}
+                {bonusBuild.length === 0 && (
+                  <span className="text-xs text-gray-500">Toca caracteres para agregarlos aquí…</span>
+                )}
+              </div>
+            </div>
+
+            {/* Tokens disponibles (10) */}
+            <div className="grid grid-cols-5 gap-2">
+              {bonusTokens.map((t, i) => (
+                <button key={'tok-'+i}
+                  onClick={() => addBonusToken(i)}
+                  className={'px-3 py-2 rounded-xl border bg-white text-center ' +
+                             (bonusBuild.includes(i) ? 'opacity-50 pointer-events-none' : 'hover:bg-orange-50')}>
+                  <div className="text-xl leading-none">{t.char}</div>
+                  <div className="text-[10px] text-gray-500">{t.pinyin}</div>
+                </button>
+              ))}
+            </div>
+          </FloatingPanel>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- implement streak tracker and hanzi bonus puzzle in RescueLivesGame
- integrate bonus life award into app-level life recovery flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b259f53c8c8325b81ca3ad2fe125a0