### PR TITLE
Add bonus heart confirmation panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -673,31 +673,24 @@ export default function App() {
                   onClose={({ pagesCompleted, totalPages, hearts, bonusLives }) => {
                     setShowRescue(false);
 
-                    // hearts puede ser 'full' | 2 | 1 | 0  — bonusLives es 0 o 1
-                    let added = 0;
+                    // hearts: 'full' | 2 | 1 | 0
                     if (hearts === 'full') {
                       setLives(MAX_LIVES);
-                      added = MAX_LIVES; // para el panel de resumen si lo usas
+                      setGameOverType(null);
                     } else if (hearts >= 2) {
                       setLives(prev => Math.min(MAX_LIVES, (prev || 0) + hearts));
-                      added = hearts;
+                      setGameOverType(null);
                     } else if (hearts === 1) {
                       setLives(prev => Math.min(MAX_LIVES, (prev || 0) + 1));
-                      added = 1;
+                      setGameOverType(null);
                     }
 
                     if (bonusLives) {
                       setLives(prev => Math.min(MAX_LIVES, (prev || 0) + bonusLives));
-                      added += bonusLives;
-                    }
-
-                    if ((hearts === 'full') || (hearts >= 1) || (bonusLives >= 1)) {
-                      // Hay al menos 1 vida para seguir jugando
                       setGameOverType(null);
                     }
 
-                    // Si usas panel de “vidas recuperadas”, puedes mostrar “+1 por bonus” en el copy:
-                    setRescueSummary({ hearts: hearts, bonus: bonusLives, pagesCompleted, totalPages });
+                    setRescueSummary({ hearts, bonus: bonusLives, pagesCompleted, totalPages });
                   }}
                 />
               )}

--- a/src/components/RescueLivesGame.jsx
+++ b/src/components/RescueLivesGame.jsx
@@ -66,6 +66,8 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
   const [bonusOpen, setBonusOpen] = React.useState(false);        // muestra el panel del bonus
   const [bonusAwarded, setBonusAwarded] = React.useState(false);  // ya ganado en esta sesión
   const [bonusLives, setBonusLives] = React.useState(0);          // 0 o 1
+  // NUEVO: panel de confirmación al terminar el bonus con éxito
+  const [bonusCongratsOpen, setBonusCongratsOpen] = React.useState(false);
 
   // Fuente para el bonus: palabras resueltas en la sesión (multi-caracter)
   const sessionSolvedWordsRef = React.useRef(new Set());
@@ -135,10 +137,14 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
     const str = currentBonusString();
     const ok = bonusTargets.some(t => t.replace(/\s+/g,'') === str);
     if (ok) {
-      setBonusLives(1);
+      setBonusLives(1);         // +1 vida bonus (se aplicará al final del minijuego)
       setBonusAwarded(true);
+      setBonusOpen(false);      // cerrar el editor del bonus
+      setBonusCongratsOpen(true); // mostrar pantalla de “ganaste”
+    } else {
+      // falló: solo cerrar el editor del bonus (sin premio)
+      setBonusOpen(false);
     }
-    setBonusOpen(false); // cerrar bonus tras intentar (ganado o no)
   };
 
   // construir página
@@ -350,6 +356,24 @@ export default function RescueLivesGame({ levels, currentLevel, onClose }) {
             </div>
           </FloatingPanel>
         )}
+
+        {/* Panel de cierre del bonus: confirma premio y vuelve al minijuego */}
+        <FloatingPanel
+          open={bonusCongratsOpen}
+          title="¡Bonus completado!"
+          onClose={() => setBonusCongratsOpen(false)}
+          actions={[
+            {
+              label: 'Seguir',
+              className: 'px-4 py-2 rounded-xl bg-emerald-600 text-white',
+              onClick: () => setBonusCongratsOpen(false)
+            }
+          ]}
+        >
+          <div className="text-sm text-gray-700">
+            ¡Ganaste un corazón <b>bonus</b>! Rescata las vidas que puedas y sigue jugando.
+          </div>
+        </FloatingPanel>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show a floating confirmation panel when the bonus phrase is solved, awarding one bonus heart
- close the bonus editor and track bonus lives for global hearts on minigame exit
- simplify RescueLivesGame onClose handler in App to apply bonus lives and reset game over state

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2606edd7483258b2fc3e5d07632ed