### PR TITLE
feat: improve bonus validation and feedback

### DIFF
--- a/src/components/FloatingPanel.jsx
+++ b/src/components/FloatingPanel.jsx
@@ -11,8 +11,12 @@ export default function FloatingPanel({ open, title, children, onClose, actions 
         <div className="mb-5">{children}</div>
         <div className="flex flex-wrap gap-3 justify-end">
           {actions.map((a, i) => (
-            <button key={i} onClick={a.onClick}
-              className={a.className || "px-4 py-2 rounded-xl border"}>
+            <button
+              key={i}
+              onClick={a.onClick}
+              className={a.className || "px-4 py-2 rounded-xl border"}
+              disabled={a.disabled}
+            >
               {a.label}
             </button>
           ))}


### PR DESCRIPTION
## Summary
- add normalize and eqHanzi helpers for comparing bonus words
- show feedback and disable button while checking bonus guesses
- allow FloatingPanel actions to be disabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b26a103bbc83259ec3fe9593fec8e9